### PR TITLE
docs: Update README.md for clarity and add Docker support; update keycloak versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM maven:3.9.9-amazoncorretto-21 AS builder
+
+WORKDIR /app
+COPY . .
+RUN mvn clean package
+
+FROM quay.io/keycloak/keycloak:26.1.2
+COPY --from=builder /app/target/*.jar /opt/keycloak/providers/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Keycloak 2FA Rest API Extension
+# Keycloak 2FA REST API Extension
 
-khode-2fa is a Keycloak extension that provides a REST API for managing Time-based One-Time Password (TOTP)
-authentication. This extension allows you to set up, verify, enable, disable, and validate TOTP for users in a Keycloak
-realm.
+khode-2fa is a Keycloak extension that provides a REST API for managing Time-based One-Time Password (TOTP) authentication. This extension allows you to set up, verify, enable, disable, and validate TOTP for users in a Keycloak realm.
 
 ## Features
 
@@ -13,12 +11,11 @@ realm.
 - Validate TOTP code
 - Disable TOTP for a user
 - Flexible authentication support:
-   - Client credentials (service account) authentication
-   - User token authentication
-   - Per-endpoint authorization controls
+  - Client credentials (service account) authentication
+  - User token authentication
+  - Per-endpoint authorization controls
 
-This extension is designed to integrate seamlessly with existing Keycloak deployments, offering developers and
-administrators greater flexibility in implementing and managing 2FA.
+This extension is designed to integrate seamlessly with existing Keycloak deployments, offering developers and administrators greater flexibility in implementing and managing 2FA.
 
 ## Installation
 
@@ -27,34 +24,76 @@ You can either build the JAR file from source or download a pre-built version fr
 ### Option 1: Download from Releases
 
 1. Go to the [Releases](https://github.com/chornthorn/khode-two-factor-auth/releases) page
-2. Download the latest `khode-two-factor-auth-x.x.x.jar` file (e.g. `khode-two-factor-auth-1.1.0.jar`)
-3. Copy the JAR file to your Keycloak deployments directory:
+2. Download the latest `khode-two-factor-auth-x.x.x.jar` file (e.g. `khode-two-factor-auth-1.4.0.jar`)
+3. Copy the JAR file to your Keycloak deployments directory and set proper permissions:
 
-   ```
-   cp khode-two-factor-auth-1.1.0.jar /path/to/keycloak/providers/
+   ```bash
+   # Copy the file
+   cp khode-two-factor-auth-1.4.0.jar /path/to/keycloak/providers/
+   
+   # Set proper ownership (assuming keycloak is the user/group)
+   sudo chown keycloak:keycloak /path/to/keycloak/providers/khode-two-factor-auth-*.jar
+   
+   # Set proper permissions
+   sudo chmod 644 /path/to/keycloak/providers/khode-two-factor-auth-*.jar
    ```
 
 ### Option 2: Build from Source
 
 1. Clone the repository:
-   ```
+   ```bash
    git clone https://github.com/chornthorn/khode-two-factor-auth.git
    ```
 
 2. Change to the project directory:
-   ```
+   ```bash
    cd khode-two-factor-auth
    ```
 
 3. Build the project using Maven:
-   ```
+   ```bash
    mvn clean package
    ```
 
-4. Copy the resulting JAR file to the Keycloak deployments directory:
+4. Copy the resulting JAR file to the Keycloak deployments directory and set proper permissions:
+   ```bash
+   # Copy the file
+   cp target/khode-two-factor-auth-*.jar /path/to/keycloak/providers/
+   
+   # Set proper ownership (assuming keycloak is the user/group)
+   sudo chown keycloak:keycloak /path/to/keycloak/providers/khode-two-factor-auth-*.jar
+   
+   # Set proper permissions (readable by owner and group)
+   sudo chmod 644 /path/to/keycloak/providers/khode-two-factor-auth-*.jar
    ```
-   cp target/khode-two-factor-auth-[version-number].jar /path/to/keycloak/providers/
+
+### Option 3: Using Docker
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/chornthorn/khode-two-factor-auth.git
    ```
+
+2. Build the Docker image:
+    ```bash
+    cd khode-two-factor-auth
+    docker build -t khode-keycloak:latest .
+    ```
+
+    #### For MacOS with Apple Silicon (M1/M2) or other ARM-based systems, specify the platform:
+    ```bash
+    cd khode-two-factor-auth
+    docker build --platform linux/amd64 -t khode-keycloak:latest .
+    ```
+
+3. Run the container:
+   ```bash
+   docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin khode-keycloak:latest start-dev
+   ```
+
+4. Access Keycloak at http://localhost:8080
+
+The Docker image is based on the official Keycloak image and includes the 2FA extension pre-installed.
 
 After installing using either method, restart Keycloak to load the new extension.
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,26 +9,33 @@
     <version>1.4.0</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <keycloakVersion>26.1.2</keycloakVersion>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>26.0.5</version>
+            <version>${keycloakVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>26.0.5</version>
+            <version>${keycloakVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>26.0.5</version>
+            <version>${keycloakVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>26.0.5</version>
+            <version>${keycloakVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -66,12 +73,6 @@
         </dependency>
     </dependencies>
 
-    <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
@@ -103,6 +104,5 @@
             <url>https://maven.pkg.github.com/${GITHUB_REPOSITORY}</url>
         </repository>
     </distributionManagement>
-
 
 </project>


### PR DESCRIPTION
# Update Project Configuration and Documentation

## Changes
- New Dockerfile and Instructions to build in Docker
- Update Keycloak version to 26.1.2 in both pom.xml and Dockerfile
- Add platform-specific Docker build instructions for ARM/Apple Silicon
- Improve installation instructions with proper file permissions by adding ownership and permission commands (chmod 644, chown) in README

## Technical Details
- Maven builder image: maven:3.9.9-amazoncorretto-21
- Keycloak base image: quay.io/keycloak/keycloak:26.1.2
- File permissions: 644 (rw-r--r--)
- Added ARM64 platform build flag for ARM64 Mac support

## Testing
Tested on:
- x86_64 Linux
- ARM64 (Apple Silicon)